### PR TITLE
Add initialization support

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,16 @@ Or just download src/angular-googleapi.js
 
 Then in your angular module add angular-googleapi as a dependency.
 
+Usage
+-----
+
+The module will automatically load and initialize the Google API.
+There is no need to manually include a `<script>` element to load the API.
+Once the API is ready, it will broadcast a `google:ready` message to $rootScope.
+
+Once this has occurred, call `googleLogin.login()` to perform the login operation.
+This method returns a promise.
+
 Demo
 ----
 


### PR DESCRIPTION
This adds a new message when the initialization is complete, and removes
the non-functional check for authentication at startup.

Since this check never worked, the overall behavior should be identical,
except that
* the script element is no longer required, and
* it is now possible for users to wait until the API is initialized